### PR TITLE
add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: go
+
+go:
+  - "1.10"
+  - "1.9"
+  - "1.8"
+  
+script:
+  - go build
+  - go test -v -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 goini	
 ========
-[![Build Status](https://drone.io/github.com/widuu/goini/status.png)](https://drone.io/github.com/widuu/goini/latest)
+[![Build Status](https://travis-ci.org/widuu/goini.svg?branch=master)](https://travis-ci.org/widuu/goini)
 
 **[The official website](http://www.widuu.com)**
 ##描述


### PR DESCRIPTION
之前提交了一个错误代码, 导致工程编译不过, 我真的是非常抱歉. 
我看你之前的 drone.io 好像也不好使了, 所以增加了travis的集成.
合并之后在 https://travis-ci.org 授一下权,打开本项目的自动集成就可以了.
这样以后所有人的Pull Request都可以看到编译和测试结果,可以避免合并到build或test不通过的代码
